### PR TITLE
--no-deps pip parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ change.
 ```
 module "python_lambda_archive" {
     source = "rojopolis/lambda-python-archive/aws"
-    src_dir = "${path.module}/python"
-    output_path = "${path.module}/lambda.zip"
+
+    src_dir              = "${path.module}/python"
+    output_path          = "${path.module}/lambda.zip"
+    install_dependencies = false
 }
 
 resource "aws_iam_role" "iam_for_lambda" {

--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,8 @@
 data "external" "lambda_archive" {
     program = ["python3", "${path.module}/scripts/build_lambda.py"]
     query = {
-        src_dir     = var.src_dir
-        output_path = var.output_path
+        src_dir              = var.src_dir
+        output_path          = var.output_path
         install_dependencies = var.install_dependencies
     }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,8 @@
 data "external" "lambda_archive" {
     program = ["python3", "${path.module}/scripts/build_lambda.py"]
     query = {
-        src_dir     = "${var.src_dir}"
-        output_path = "${var.output_path}"
+        src_dir     = var.src_dir
+        output_path = var.output_path
+        install_dependencies = var.install_dependencies
     }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,9 @@
 output "archive_path" {
     description = "Path of the archive file."
-    value       = "${data.external.lambda_archive.result.archive}"
+    value       = data.external.lambda_archive.result.archive
 }
 
 output "source_code_hash" {
     description = "Base64 encoded SHA256 hash of the archive file."
-    value       = "${data.external.lambda_archive.result.base64sha256}"
+    value       = data.external.lambda_archive.result.base64sha256
 }

--- a/scripts/build_lambda.py
+++ b/scripts/build_lambda.py
@@ -72,4 +72,4 @@ if __name__ == '__main__':
     query = json.loads(sys.stdin.read())
     logging.debug(query)
     archive = build(query['src_dir'], query['output_path'])
-    print(json.dumps({'archive': archive, "base64sha256":get_hash(archive)}))
+    print(json.dumps({'archive': archive, 'base64sha256':get_hash(archive)}))

--- a/scripts/build_lambda.py
+++ b/scripts/build_lambda.py
@@ -13,7 +13,7 @@ import sys
 import tempfile
 import zipfile
 
-def build(src_dir, output_path):
+def build(src_dir, output_path, install_dependencies):
     with tempfile.TemporaryDirectory() as build_dir:
         copy_tree(src_dir, build_dir)
         if os.path.exists(os.path.join(src_dir, 'requirements.txt')):
@@ -24,7 +24,8 @@ def build(src_dir, output_path):
                  'install',
                  '--ignore-installed',
                  '--target', build_dir,
-                 '-r', os.path.join(build_dir, 'requirements.txt')],
+                 '-r', os.path.join(build_dir, 'requirements.txt'),
+                 *(['--no-deps'] if install_dependencies == 'false' else [])],
                  check=True,
                  stdout=subprocess.DEVNULL,
             )
@@ -71,5 +72,5 @@ if __name__ == '__main__':
     logging.basicConfig(level='DEBUG')
     query = json.loads(sys.stdin.read())
     logging.debug(query)
-    archive = build(query['src_dir'], query['output_path'])
+    archive = build(query['src_dir'], query['output_path'], query['install_dependencies'])
     print(json.dumps({'archive': archive, 'base64sha256':get_hash(archive)}))

--- a/variables.tf
+++ b/variables.tf
@@ -1,9 +1,15 @@
 variable "src_dir" {
     description = "Path to root of Python source to package."
-    type        = "string"
+    type        = string
 }
 
 variable "output_path" {
     description = "The output of the archive file."
-    type        = "string"
+    type        = string
+}
+
+variable "install_dependencies" {
+    description = "Whether to install pip dependecies"
+    type        = bool
+    default     = true
 }


### PR DESCRIPTION
In order to reduce the zip archive size implemented an additional --no-deps argument for PIP.
AWS hard limit on the zipped package is [50MB](https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-limits.html)