### PR TITLE
Sorted file listing

### DIFF
--- a/scripts/build_lambda.py
+++ b/scripts/build_lambda.py
@@ -43,8 +43,12 @@ def make_archive(src_dir, output_path):
             raise
 
     with zipfile.ZipFile(output_path, 'w') as archive:
+        paths = dict()
         for root, dirs, files in os.walk(src_dir):
-            for file in files:
+            paths[root] = files
+
+        for root in sorted(list(paths.keys())):
+            for file in sorted(paths[root]):
                 if file.endswith('.pyc'):
                     break
                 metadata = zipfile.ZipInfo(


### PR DESCRIPTION
When running this module back to back the ZIP archive hash can change because the file paths can be random from `os.walk()`. This change will make sure the ordering of paths is predictable, resulting in the order files are added to the archive also being predictable.